### PR TITLE
Update VirgilE3Kit

### DIFF
--- a/ios/virgil_e3kit.podspec
+++ b/ios/virgil_e3kit.podspec
@@ -11,7 +11,7 @@ Virgil virgil_e3kit.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'VirgilE3Kit', '~> 3.0.1'
+  s.dependency 'VirgilE3Kit', '~> 4.0.1'
   s.platform = :ios, '8.0'
   
   # Flutter.framework does not contain a i386 slice.

--- a/ios/virgil_e3kit.podspec
+++ b/ios/virgil_e3kit.podspec
@@ -11,7 +11,7 @@ Virgil virgil_e3kit.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'VirgilE3Kit', '~> 2.0.0'
+  s.dependency 'VirgilE3Kit', '~> 3.0.1'
   s.platform = :ios, '8.0'
   
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
The VirgilE3Kit dependency is outdated, causing some errors while compiling and also not allowing the Flutter version to have the latest in terms of features, security patches, etc.

In my case, I was experiencing this issue [https://github.com/VirgilSecurity/virgil-crypto-x/issues/33](url), updating the version fixed the problem.