### PR TITLE
Add namespace to build.gradle files

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,8 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 31
 
+    namespace 'com.virgilsecurity.virgil_e3kit'
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -28,6 +28,8 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 31
 
+    namespace 'com.virgilsecurity.virgil_e3kit_example'
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,10 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
+android {
+    namespace 'com.virgilsecurity.virgil_e3kit_example'
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
Fixes #15

Add namespace declarations to `build.gradle` files to comply with new Flutter versions.

* **android/build.gradle**
  - Add `namespace 'com.virgilsecurity.virgil_e3kit'` under the `android` block.

* **example/android/app/build.gradle**
  - Add `namespace 'com.virgilsecurity.virgil_e3kit_example'` under the `android` block.

* **example/android/build.gradle**
  - Add `namespace 'com.virgilsecurity.virgil_e3kit_example'` under the `android` block.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/VirgilSecurity/virgil-e3kit-flutter/pull/16?shareId=c98090a8-8a06-4b2b-93a3-5529b06e6ad8).